### PR TITLE
fix footer commit: commit id of specified file

### DIFF
--- a/server/action.go
+++ b/server/action.go
@@ -563,6 +563,7 @@ func getHistory(fp string, size int) ([]CommitEntry, error) {
 		return nil, err
 	}
 
+	// walk commits descending by time
 	revwalk.Sorting(git.SortTime)
 
 	var filehistory []CommitEntry
@@ -592,18 +593,19 @@ func getHistory(fp string, size int) ([]CommitEntry, error) {
 				filehistory = append(filehistory, buildCommitEntry(commit, entry))
 			} else {
 				if filehistory[filehistoryLen-1].EntryId == entry.Id.String() {
-					// replace the last commit having the same entry id
-					// why ??
+					// earlier commit points to the same file entry
+					// it means that the later one didn't change the file, so replace it
 					filehistory = filehistory[:filehistoryLen-1]
 					filehistory = append(filehistory, buildCommitEntry(commit, entry))
 				} else {
-					// new entry id means last entry id is done
+					// earlier commit points to the new file entry
+					// it means that the later one has changed the file
 					cnt += 1
 					if size > 0 && cnt >= size {
 						return false
 					}
 
-					// new commit with new entry id
+					// add the commit with new file entry
 					filehistory = append(filehistory, buildCommitEntry(commit, entry))
 				}
 			}


### PR DESCRIPTION
原先在 getHistory(fp,1) 时，获取到第一个 commit 之后添加进 filehistory ，判断已满足 size 要求即停止继续获取，导致只能展示整体的第一个 commit id

修改后会在确定第一个做出修改的 commit 后再停止继续获取