### PR TITLE
move 'cdn.mathjax.org' to 'cdnjs.cloudflare.com'

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -365,7 +365,7 @@ function render(newNode, markdown, theme, heading_number, show_toc){
     if(!window.MathJax){
         var script = document.createElement("script");
         script.type = "text/javascript";
-        script.src  = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_SVG";
+        script.src  = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js?config=TeX-AMS-MML_SVG";
 
         var callback = function () {
           // config options


### PR DESCRIPTION
WARNING: cdn.mathjax.org has been retired. Check https://www.mathjax.org/cdn-shutting-down/ for migration tips.